### PR TITLE
Modify Api

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,11 @@ Changelog
 1.0a2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Modify Api:
+  * return objects by default, optionally return a dict by relationname
+  * check view-permissions by default
+  * add convenience-methods relations, backrelations, unrestricted_relations and unrestricted_backrelations
+  * add convenience-method relation for relationChoice that only returns one object, not a list
 
 
 1.0a1 (2020-05-29)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Changelog
   * check view-permissions by default
   * add convenience-methods relations, backrelations, unrestricted_relations and unrestricted_backrelations
   * add convenience-method relation for relationChoice that only returns one object, not a list
+  * rename parameter backref to backrel
+  * allow to query for multiple reations
 
 
 1.0a1 (2020-05-29)

--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,23 @@ First import the api: ``from collective.relationhelpers import api as relapi``
 Dealing with relations on individual objects
 --------------------------------------------
 
+Convenience Api
+
+``relations(obj, attribute=None, as_dict=False)``
+    Get related objects.
+
+``unrestricted_relations(obj, attribute=None, as_dict=False)``
+    Get related objects without permission checks.
+
+``backrelations(obj, attribute=None, as_dict=False)``
+    Get objects with a relation to this object.
+
+``unrestricted_backrelations(obj, attribute=None, as_dict=False)``
+    Get objects with a relation to this object without permission checks.
+
+``relation(obj, attribute, restricted=True)``
+    Get related object. This is only valid if the attribute is the name of a relationChoice field on the object.
+
 ``relapi.link_objects(source, target, relationship)``
     Link objects: Create a relation between two objects using the specified relationship.
     From the parameter ``relationship`` the method will find out what kind of relationship you want to create (RelationChoice, RelationList) by inspecting the schema-field on the source-object.
@@ -71,25 +88,12 @@ Dealing with relations on individual objects
 
     Example: To use the default-behavior ``plone.relateditems`` use the field-name ``relatedItems`` as relationship: ``relapi.link_objects(obj, anotherobj, 'relatedItems')``.
 
-``relapi.get_relations(obj, attribute=None, backrefs=False, fullobj=False)``
+``relapi.get_relations(obj, attribute=None, backrefs=False, restricted=True, as_dict=False)``
     Get a list of incoming or outgoing relation for a specific content object.
 
     If you pass a attribute (i.e. the ``from_attribute`` of the relation) you can use it to get only specific relations.
 
-    The result is returned as a dict with the following values:
-
-    ``id``: The id of the related or relating (for backreferences) object
-
-    ``href``: The url of the object
-
-    ``title``: The title
-
-    ``relation``: The name of the relation (i.e. field).
-
-    ``fullobj``: The obj (optional)
-
-``relapi.get_backrelations(obj, attribute=None, fullobj=False)``
-    Wrapper for ``get_relations`` that only return backrelations.
+    The result is a list of objects or (if you use as_dict) a dict with the relations as keys and lists of objects as values.
 
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ First import the api: ``from collective.relationhelpers import api as relapi``
 Dealing with relations on individual objects
 --------------------------------------------
 
-Convenience Api
+**Convenience methods:**
 
 ``relations(obj, attribute=None, as_dict=False)``
     Get related objects.
@@ -78,8 +78,18 @@ Convenience Api
 ``unrestricted_backrelations(obj, attribute=None, as_dict=False)``
     Get objects with a relation to this object without permission checks.
 
-``relation(obj, attribute, restricted=True)``
+``relation(obj, attribute)``
     Get related object. This is only valid if the attribute is the name of a relationChoice field on the object.
+
+``unrestricted_relation(obj, attribute)``
+    Get related object without permission checks. See relation
+
+``backrelation(obj, attribute)``
+    Get relating object. This only makes sense when one item has a relation of this type to the obj.
+    One example is parent -> child where only one parent can exist.
+
+``unrestricted_backrelation(obj, attribute)``
+    Get relating object without permission checks. See backrelation
 
 ``relapi.link_objects(source, target, relationship)``
     Link objects: Create a relation between two objects using the specified relationship.
@@ -88,12 +98,15 @@ Convenience Api
 
     Example: To use the default-behavior ``plone.relateditems`` use the field-name ``relatedItems`` as relationship: ``relapi.link_objects(obj, anotherobj, 'relatedItems')``.
 
-``relapi.get_relations(obj, attribute=None, backrefs=False, restricted=True, as_dict=False)``
+
+**Main method to get all kinds of relations:**
+
+``relapi.get_relations(obj, attribute=None, backrels=False, restricted=True, as_dict=False)``
     Get a list of incoming or outgoing relation for a specific content object.
 
-    If you pass a attribute (i.e. the ``from_attribute`` of the relation) you can use it to get only specific relations.
+    If you pass a attribute you only get relations of that type. This is the same as the fieldname on the source-object and the ``from_attribute`` on a RelationValue. You can also pass a list if attributes to get relations of certain types.
 
-    The result is a list of objects or (if you use as_dict) a dict with the relations as keys and lists of objects as values.
+    By default the result is a list of objects. If you set as_dict=True it will return a dict with the names of the relations as keys and lists of objects as values.
 
 
 Installation

--- a/src/collective/relationhelpers/__init__.py
+++ b/src/collective/relationhelpers/__init__.py
@@ -2,5 +2,4 @@
 """Init and utils."""
 from zope.i18nmessageid import MessageFactory
 
-
 _ = MessageFactory('collective.relationhelpers')

--- a/src/collective/relationhelpers/api.py
+++ b/src/collective/relationhelpers/api.py
@@ -300,7 +300,6 @@ def get_relations(obj, attribute=None, backrels=False, restricted=True, as_dict=
         query['from_id'] = int_id
 
     if restricted:
-        sm = getSecurityManager()
         checkPermission = getSecurityManager().checkPermission
 
     if attribute and isinstance(attribute, (list, tuple)):

--- a/src/collective/relationhelpers/api.py
+++ b/src/collective/relationhelpers/api.py
@@ -1,4 +1,5 @@
 # -*- coding: UTF-8 -*-
+from AccessControl.SecurityManagement import getSecurityManager
 from collections import Counter
 from collections import defaultdict
 from plone import api
@@ -276,18 +277,21 @@ def link_objects(source, target, relationship):
         from_attribute, source.absolute_url(), target.absolute_url()))
 
 
-def get_relations(obj, attribute=None, backrefs=False, fullobj=False):
+# Main API method
+
+def get_relations(obj, attribute=None, backrefs=False, restricted=True, as_dict=False):
     """Get specific relations or backrelations for a content object
-    TODO: Maybe check view permissions and conditionally return stubs
     """
-    retval = []
+    results = []
+    if as_dict:
+        results = defaultdict(list)
     int_id = get_intid(obj)
     if not int_id:
-        return retval
+        return results
 
     relation_catalog = getUtility(ICatalog)
     if not relation_catalog:
-        return retval
+        return results
 
     query = {}
     if attribute:
@@ -298,36 +302,105 @@ def get_relations(obj, attribute=None, backrefs=False, fullobj=False):
     else:
         query['from_id'] = int_id
 
+    if restricted:
+        sm = getSecurityManager()
+        checkPermission = getSecurityManager().checkPermission
+
     relations = relation_catalog.findRelations(query)
     for relation in relations:
         if relation.isBroken():
-            value = dict(
-                href='',
-                title=u'Broken relation',
-                relation=relation.from_attribute)
-            if fullobj:
-                value['fullobj'] = None
-            retval.append(value)
+            continue
+
+        if backrefs:
+            obj = relation.from_object
         else:
-            if backrefs:
-                obj = relation.from_object
+            obj = relation.to_object
+
+        if as_dict:
+            if restricted:
+                if checkPermission('View', obj):
+                    results[relation.from_attribute].append(obj)
+                else:
+                    results[relation.from_attribute].append(None)
             else:
-                obj = relation.to_object
-            value = dict(
-                id=obj.id,
-                href=obj.absolute_url(),
-                title=obj.title,
-                relation=relation.from_attribute)
-            if fullobj:
-                value['fullobj'] = obj
-            retval.append(value)
-    return retval
+                results[relation.from_attribute].append(obj)
+        else:
+            if restricted:
+                if checkPermission('View', obj):
+                    results.append(obj)
+            else:
+                results.append(obj)
+    return results
 
 
-def get_backrelations(obj, attribute=None, fullobj=False):
-    """Get backrelations"""
-    return get_relations(
-        obj, attribute=attribute, backrefs=True, fullobj=fullobj)
+# Convenience API
+
+def relations(obj, attribute=None, as_dict=False):
+    """Get related objects"""
+    return get_relations(obj, attribute=attribute, restricted=True, as_dict=as_dict)
+
+
+def unrestricted_relations(obj, attribute=None, as_dict=False):
+    """Get related objects without permission check"""
+    return get_relations(obj, attribute=attribute, restricted=False, as_dict=as_dict)
+
+
+def backrelations(obj, attribute=None, as_dict=False):
+    """Get objects with a relation to this object."""
+    return get_relations(obj, attribute=attribute, backrefs=True, restricted=True, as_dict=as_dict)
+
+
+def unrestricted_backrelations(obj, attribute=None, as_dict=False):
+    """Get objects with a relation to this object without permission check"""
+    return get_relations(obj, attribute=attribute, backrefs=True, restricted=False, as_dict=as_dict)
+
+
+# Convenience api to deal with relationchoice
+
+def relation(obj, attribute, restricted=True):
+    """Get related object.
+    Only valid if the attribute is the name of a relationChoice field on the object.
+    """
+    if not attribute:
+        raise RuntimeError(u'Missing parameter "attribute"')
+
+    check_for_relationchoice(obj, attribute)
+    items = get_relations(obj, attribute=attribute, restricted=False)
+    if items:
+        return items[0]
+
+
+def backrelation(obj, attribute):
+    """Get relating object.
+    This makes sense when only one item has a relation of this type to obj.
+    One example is parent -> child where only one parent can exist.
+    """
+    if not attribute:
+        raise RuntimeError(u'Missing parameter "attribute"')
+
+    items = get_relations(obj, attribute=attribute, backrefs=True)
+    if len(items) > 1:
+        raise RuntimeError(u'Multiple incoming relations of type {}.'.format(attribute))
+
+    if items:
+        source_obj = items[0]
+        check_for_relationchoice(source_obj, attribute)
+        return source_obj
+
+
+def check_for_relationchoice(source_obj, attribute):
+    """Raise a exception if the attribute is no rewlationchoice field."""
+    fti = getUtility(IDexterityFTI, name=source_obj.portal_type)
+    field_and_schema = get_field_and_schema_for_fieldname(attribute, fti)
+    if field_and_schema is None:
+        # No field found
+        raise RuntimeError(u'{} is no field on {}.'.format(
+            attribute, source_obj.portal_type))
+    field, schema = field_and_schema
+    if not isinstance(field, (Relation, RelationChoice)):
+        # No RelationChoice field found
+        raise RuntimeError(u'{} is no RelationChoice field for {}.'.format(
+            attribute, source_obj.portal_type))
 
 
 def get_intid(obj):


### PR DESCRIPTION
* return objects by default, optionally return a dict by relationname
* check view-permissions by default
* add convenience-methods relations, backrelations, unrestricted_relations and unrestricted_backrelations
* add convenience-method relation for relationChoice that only returns one object, not a list