### PR TITLE
PyPI egg is not installable on Python > 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     package_dir={'': 'src'},
     include_package_data=True,
     zip_safe=False,
-    python_requires="==2.7, >=3.6",
+    python_requires='>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*',
     install_requires=[
         'setuptools',
         # -*- Extra requirements: -*-


### PR DESCRIPTION
The reason is related to the `python_requires` line in the setup.py
```
[ale@emily test]$ ./bin/pip install -e collective.relationhelpers/
Looking in links: file:///home/ale/.pip-wheelhouse
Obtaining file:///home/ale/tmp/test/collective.relationhelpers
ERROR: Package 'collective.relationhelpers' requires a different Python: 3.8.2 not in '==2.7, >=3.6'
```
This patch fixes it.

I did not add a changelog (seems such a silly addition).
The issue will be close by a new PyPI release.