### PR TITLE
Fixed query for existing relations in link_objects.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Changelog
 1.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Fixed query for existing relations in ``link_objects``.
+  [maurits]
 
 
 1.2 (2021-01-13)

--- a/src/collective/relationhelpers/api.py
+++ b/src/collective/relationhelpers/api.py
@@ -327,14 +327,15 @@ def link_objects(source, target, relationship):
     relation_catalog = getUtility(ICatalog)
     intids = getUtility(IIntIds)
     to_id = intids.getId(target)
+    from_id = intids.getId(source)
     from_attribute = relationship
 
     # Check if there is exactly this relation.
     # If so remove it and create a fresh one.
     query = {
         'from_attribute': from_attribute,
-        'from_id': source.UID(),
-        'to_id': target.UID(),
+        'from_id': from_id,
+        'to_id': to_id,
     }
     for rel in relation_catalog.findRelations(query):
         relation_catalog.unindex(rel)


### PR DESCRIPTION
The code did a query for uids instead of intids, so it did not find any relations to unindex.

Note: when calling `link_objects` multiple times with the same arguments, I did not see extra relations appear when searching for `relation_catalog.findRelations({'to_id': <actual intid>})`. So it does not seem to have had bad effects. But still better to fix it.